### PR TITLE
Fixes the keyserver host name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@
 # Copyright 2011-2012, Phil Cohen
 #
 
-default["new_relic"]["keyserver"]      = "pgp.mit.edu"
+default["new_relic"]["keyserver"]      = "subkeys.pgp.net"
 default["new_relic"]["license_key"]    = ""
 default["new_relic"]["loglevel"]       = "info"
 default["new_relic"]["logfile"]        = "/var/log/newrelic/nrsysmond.log"


### PR DESCRIPTION
Thank you for this cookbook! It makes it extremely easy to get the NewRelic monitoring agent running...

It appears the key is available from subkeys.pgp.net, not pgp.mit.edu as previously listed in the attributes.
