### PR TITLE
Update default `keyserver` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This cookbook installs the newrelic-sysmond components if not present, and pulls
 ## Attributes
 
 ```ruby
-default["new_relic"]["keyserver"]      = "subkeys.pgp.net"
+default["new_relic"]["keyserver"]      = "keyserver.ubuntu.com"
 default["new_relic"]["license_key"]    = ""
 default["new_relic"]["loglevel"]       = "info"
 default["new_relic"]["logfile"]        = "/var/log/newrelic/nrsysmond.log"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@
 # Copyright 2011-2012, Phil Cohen
 #
 
-default["new_relic"]["keyserver"]      = "subkeys.pgp.net"
+default["new_relic"]["keyserver"]      = "keyserver.ubuntu.com"
 default["new_relic"]["license_key"]    = ""
 default["new_relic"]["loglevel"]       = "info"
 default["new_relic"]["logfile"]        = "/var/log/newrelic/nrsysmond.log"


### PR DESCRIPTION
Per #6, some users received the following error:

```
gpg: keyserver timed out
```

The Ubuntu keyserver seems to be a more reliable default.
