### PR TITLE
Add support for setting the hostname

### DIFF
--- a/templates/default/nrsysmond.cfg.erb
+++ b/templates/default/nrsysmond.cfg.erb
@@ -15,6 +15,10 @@
 #
 license_key=<%= node["new_relic"]["license_key"] %>
 
+<% if node["fqdn"] %>
+hostname=<%= node["fqdn"] %>
+<% end %>
+
 #
 # Option : loglevel
 # Value  : Level of detail you want in the log file (as defined by the logfile


### PR DESCRIPTION
Newrelic allows
http://docs.newrelic.com/docs/server/changing-the-linux-server-name#configuration-file

In our case, we need to set the server name to something meaningful via the `hostname` cookbook. Unfortunately, this causes a bit of trouble in newrelic, as after reboot, sometimes the hostname changes, causing 'phantom' servers to appear.
