### PR TITLE
Adding logging if no licence key

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@
 if node["new_relic"]["license_key"].empty?
   log "message" do
       message "newrelic-sysmond recipe included, but licence key not provided."
-      level :info
+      level :warn
   end
 
   return

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,14 @@
 # Copyright 2011-2014, Phil Cohen
 #
 
-return if node["new_relic"]["license_key"].empty?
+if node["new_relic"]["license_key"].empty?
+  log "message" do
+      message "newrelic-sysmond recipe included, but licence key not provided."
+      level :info
+  end
+
+  return
+end
 
 if platform_family?("debian")
   apt_repository "newrelic" do


### PR DESCRIPTION
Just making it more clear as to why the recipe doesn't run if a licence key isn't provided. Previously it would run through silently.
