### PR TITLE
Add yum/arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Installs [newrelic-sysmond](https://newrelic.com/docs/server/new-relic-for-serve
 The following cookbooks are direct dependencies:
 
 * apt (for Debian and Ubuntu)
+* yum (for RHEL and CentOS)
 
 ### Supported Platforms
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version          "1.3.5"
 recipe "newrelic-sysmond", "Install and configure newrelic-sysmond"
 
 depends "apt", ">= 1.9.2"
+depends "yum", ">= 3.0"
 
 supports "debian"
 supports "ubuntu"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,9 +26,10 @@ if platform_family?("debian")
     keyserver node["new_relic"]["keyserver"]
   end
 elsif platform_family?("rhel")
-  execute "Add New Relic yum repository" do
-    command "rpm -Uvh http://download.newrelic.com/pub/newrelic/el5/i386/newrelic-repo-5-3.noarch.rpm"
-    not_if "yum list installed | grep newrelic-repo.noarch"
+  yum_repository 'newrelic' do
+    baseurl "https://yum.newrelic.com/pub/newrelic/el5/#{node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'i386'}"
+    gpgcheck false
+    enabled true
   end
 end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -39,28 +39,14 @@ EOM
 
   # rhel family setup
   context "using rhel platform family" do
-    let(:yum_cmd) { "yum list installed | grep newrelic-repo.noarch" }
-
     let(:chef_run) do
       ChefSpec::Runner.new(platform: "centos", version: "6.3") { |node|
         node.set["new_relic"]["license_key"] = "abc123"
       }.converge(described_recipe)
     end
 
-    context "when `newrelic-repo.noarch` is not installed" do
-      before { stub_command(yum_cmd).and_return(false) }
-
-      it "adds the New Relic Yum repository" do
-        expect(chef_run).to run_execute("Add New Relic yum repository")
-      end
-    end
-
-    context "when `newrelic-repo.noarch` is installed" do
-      before { stub_command(yum_cmd).and_return(true) }
-
-      it "does not add the New Relic Yum repository" do
-        expect(chef_run).to_not run_execute("Add New Relic yum repository")
-      end
+    it "sets up a yum repository" do
+      expect(chef_run).to create_yum_repository("newrelic")
     end
   end
 


### PR DESCRIPTION
Adds the 64bit yum repo if a 64bit OS is detected. (#13)
This is based off of how [chef-mongodb](https://github.com/edelight/chef-mongodb/blob/fd7ab07ebfd54fc1049bc37367b92842f37310ac/recipes/mongodb_org_repo.rb#L41) does it, and adds yum as a cookbook dependency.

Updated the tests for RHEL to be similar to the Debian tests.
