### PR TITLE
move apt uri and key to attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This cookbook installs the newrelic-sysmond components if not present, and pulls
 ## Attributes
 
 ```ruby
+default["new_relic"]["apt_uri"]        = "http://apt.newrelic.com/debian/"
+default["new_relic"]["apt_key"]        = "548C16BF"
 default["new_relic"]["keyserver"]      = "keyserver.ubuntu.com"
 default["new_relic"]["license_key"]    = ""
 default["new_relic"]["loglevel"]       = "info"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,8 @@
 # Copyright 2011-2014, Phil Cohen
 #
 
+default["new_relic"]["apt_uri"]        = "http://apt.newrelic.com/debian/"
+default["new_relic"]["apt_key"]        = "548C16BF"
 default["new_relic"]["keyserver"]      = "keyserver.ubuntu.com"
 default["new_relic"]["license_key"]    = ""
 default["new_relic"]["loglevel"]       = "info"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,9 +20,9 @@ end
 
 if platform_family?("debian")
   apt_repository "newrelic" do
-    uri "http://apt.newrelic.com/debian/"
+    uri node["new_relic"]["apt_uri"]
     components %w[newrelic non-free]
-    key "548C16BF"
+    key node["new_relic"]["apt_key"]
     keyserver node["new_relic"]["keyserver"]
   end
 elsif platform_family?("rhel")


### PR DESCRIPTION
moves apt repo uri to attributes and key id

one possibility here is to namespace them to `node['new_relic']['apt']['uri']`
