### PR TITLE
correcting syntax and uid/gid issues

### DIFF
--- a/files/default/newrelic-sysmond-debian.conf
+++ b/files/default/newrelic-sysmond-debian.conf
@@ -1,12 +1,15 @@
 description "New Relic Server Monitor"
 
-start on [2345]
+start on runlevel [2345]
 stop on runlevel [!2345]
 
 respawn
 respawn limit 5 20
 
-setuid newrelic
-setgid newrelic
+pre-start script
+  test -e /var/run/newrelic || mkdir /var/run/newrelic
+  chown newrelic:newrelic /var/run/newrelic
+end script
 
-exec start-stop-daemon --start --exec /usr/sbin/nrsysmond -- -f -c /etc/newrelic/nrsysmond.cfg
+exec start-stop-daemon --start --chuid newrelic --group newrelic --exec /usr/sbin/nrsysmond -- -f -c /etc/newrelic/nrsysmond.cfg
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "github@phlippers.net"
 license          "MIT"
 description      "Setup New Relic sysmond for server monitoring"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "2.0.0"
+version          "2.0.1"
 
 recipe "newrelic-sysmond", "Install and configure newrelic-sysmond"
 


### PR DESCRIPTION
fixing upstart syntax for starting at runlevel
setting up process to start as newrelic:newrelic in a way that
actually works.
