### PR TITLE
Set default apt_repository distribution to empty 

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
-  - name: centos-6.5
+  - name: centos-6.7
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@
 default["newrelic-sysmond"]["package_action"] = "install"  # or `upgrade`
 default["newrelic-sysmond"]["apt_uri"]        = "http://apt.newrelic.com/debian/"
 default["newrelic-sysmond"]["apt_key"]        = "548C16BF"
+default["newrelic-sysmond"]["apt_distribution"] = ""
 default["newrelic-sysmond"]["keyserver"]      = "hkp://keyserver.ubuntu.com:80"
 default["newrelic-sysmond"]["yum_baseurl"]    = "https://yum.newrelic.com/pub/newrelic/el5/#{node["kernel"]["machine"]}"
 default["newrelic-sysmond"]["license_key"]    = ""

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ end
 apt_repository "newrelic" do
   uri node["newrelic-sysmond"]["apt_uri"]
   components %w[newrelic non-free]
+  distribution node["newrelic-sysmond"]["apt_distribution"]
   key node["newrelic-sysmond"]["apt_key"]
   keyserver node["newrelic-sysmond"]["keyserver"]
   only_if { platform_family?("debian") }


### PR DESCRIPTION
Set default apt_repository distribution to empty to match New Relic repo structure.
